### PR TITLE
Rewrote guidebook's Controls/Interactions

### DIFF
--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -24,15 +24,12 @@ General interactions are done by clicking [color=yellow][bold][keybind="Use"][/b
 These are context-sensitive and [bold]affected by the item in your active hand[/bold].
 Using [color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] performs [bold]alternate interactions[/bold].
 
-Some items, such as bottles, require priming before use.
-To activate an item in your hand, click [color=yellow][bold][keybind="Use"][/bold][/color] on it, or just press [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color] if it's in the active hand.
-Do it a second time to use the item.
+To activate or use an item in your hand, click [color=yellow][bold][keybind="Use"][/bold][/color] on it, or just press [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color] if it's in the active hand.
 The alternate counterpart is [color=yellow][bold][keybind="AltActivateItemInHand"][/bold][/color].
 
 To perform [color=cyan]basic interactions[/color], press [color=yellow][bold][keybind="ActivateItemInWorld"][/bold][/color].
-These interactions are independent from held items.
-It's used for actions such as opening and closing containers, and activating items under your cursor, without picking them up.
-[color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] will perform alternate interactions, such as toggling power to machines.
+This type of interaction is independent from held items.
+It's used for toggling things, and opening and closing containers without picking them up.
 
 Hovering over an entity and pressing [color=yellow][bold][keybind="UIRightClick"/][/bold][/color] brings up the [color=cyan]context menu[/color].
 This not only allows you to sort through large piles of items, but also to perform [bold]additional interactions.[/bold]

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -20,15 +20,19 @@ When off-station, you will be unable to control your direction.
 [bold]Throwing objects[/bold] or [bold]spraying a fire-extinguisher[/bold] can help propel yourself while in this state.
 
 ## Interactions
-General interactions are done with [color=yellow][bold][keybind="Use"][/bold][/color].
-These are [bold]context-sensitive[/bold] and are affected by the item in your active hand.
-You can also use [color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] to perform [bold]alternate interactions[/bold].
+General interactions are done by clicking [color=yellow][bold][keybind="Use"][/bold][/color].
+These are context-sensitive and [bold]affected by the item in your active hand[/bold].
+Using [color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] performs [bold]alternate interactions[/bold].
 
-To perform [color=cyan]basic interactions[/color], use [color=yellow][bold][keybind="ActivateItemInWorld"][/bold][/color].
-This is like [bold]interacting with nothing in hand[/bold].
-It's most used for performing basic interaction while holding something, such as opening a door when your hands are full.
+Some items, such as bottles, require priming before use.
+To activate an item in your hand, click [color=yellow][bold][keybind="Use"][/bold][/color] on it, or just press [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color] if it's in the active hand.
+Do it a second time to use the item.
+The alternate counterpart is [color=yellow][bold][keybind="AltActivateItemInHand"][/bold][/color].
 
-Pressing [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color] uses or activates the item held in your active hand.
+To perform [color=cyan]basic interactions[/color], press [color=yellow][bold][keybind="ActivateItemInWorld"][/bold][/color].
+These interactions are independent from held items.
+It's used for actions such as opening and closing containers, and activating items under your cursor, without picking them up.
+[color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] will perform alternate interactions, such as toggling power to machines.
 
 Hovering over an entity and pressing [color=yellow][bold][keybind="UIRightClick"/][/bold][/color] brings up the [color=cyan]context menu[/color].
 This not only allows you to sort through large piles of items, but also to perform [bold]additional interactions.[/bold]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Rewrote the Interactions section in the Guidebook.

## Why / Balance
It all started when I realized the explanation for using the Z key was easy to misinterpret, as the word "it" refers to the second previous sentence:
![image](https://github.com/user-attachments/assets/0224dd14-e907-4ad5-8b33-6b72c39865f3)
I think most people would interpret it like this: "[Z] is mostly used for performing basic interaction while holding something". I'm a new player, but I tested it to make sure, as well as compared it to the wiki. I also rewrote more of the Interactions section for conciseness.

## Technical details
Replaced some text.

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a